### PR TITLE
chore: commitlint subject 시작 문자 규칙 수정(#14)

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -26,5 +26,6 @@ module.exports = {
     'subject-empty': [2, 'never'],
     'subject-max-length': [2, 'always', 300],
     'header-max-length': [2, 'always', 300],
+    'subject-case': [0],
   },
 };


### PR DESCRIPTION
## Summary
- 커밋 메시지의 첫 글자를 대문자로 지정하면 안되는 규칙을 제거하였습니다.

## Related Issue
- Closes #14

## Change Type
- [ ] 리팩토링
- [ ] 의존성 업데이트
- [ ] 설정 / 인프라 변경
- [ ] 툴링 / CI

## Checklist
- [ ] 기능적 변경 사항 없음
- [ ] CI / 빌드 확인 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 커밋 메시지 검증 구성을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->